### PR TITLE
Fix async reset before restart

### DIFF
--- a/nemo-runner/src/components/game/GameCanvas.tsx
+++ b/nemo-runner/src/components/game/GameCanvas.tsx
@@ -451,10 +451,10 @@ export default function GameCanvas() {
     }
   }, []); // Empty dependency array
 
-  const handleRestart = () => {
+  const handleRestart = async () => {
     if (gameEngineRef.current && gameEngineRef.current.getCurrentState() === GameState.GAME_OVER) {
       console.log("GameCanvas: Restarting game...");
-      gameEngineRef.current.resetGame();
+      await gameEngineRef.current.resetGame();
       gameEngineRef.current.start();
       setIsGameOver(false);
       setActivePowerUps([]); // Clear power-ups on restart


### PR DESCRIPTION
## Summary
- make `handleRestart` async
- wait for `resetGame` to finish before starting again

## Testing
- `npm run lint` *(fails: next not found)*