### PR TITLE
Adjust camera offset

### DIFF
--- a/nemo-runner/src/lib/game/config/gameConfig.ts
+++ b/nemo-runner/src/lib/game/config/gameConfig.ts
@@ -430,7 +430,7 @@ export const defaultConfig: GameConfig = {
     laneCount: 3,
   },
   camera: {
-    offset: { x: 0, y: 2, z: 5 }, // z is distance behind player
+    offset: { x: 0, y: 2, z: 3 }, // z is distance behind player (closer view)
     lookAtOffset: { x: 0, y: 1, z: 0 }, // Looks slightly above player's root
     lerpFactor: 0.05, // Smoothness of camera follow
   },

--- a/nemo-runner/src/lib/game/core/CameraManager.ts
+++ b/nemo-runner/src/lib/game/core/CameraManager.ts
@@ -19,7 +19,7 @@ export class CameraManager {
     this.offset = new THREE.Vector3(
       configSystem.get('camera')?.offset?.x || 0,
       configSystem.get('camera')?.offset?.y || 2,
-      configSystem.get('camera')?.offset?.z || 5
+      configSystem.get('camera')?.offset?.z || 3
     );
     this.lookAtOffset = new THREE.Vector3(
       configSystem.get('camera')?.lookAtOffset?.x || 0,


### PR DESCRIPTION
## Summary
- move the default camera closer to the player
- keep CameraManager fallback consistent with new config

## Testing
- `npm run lint` *(fails: next not found)*