### PR TITLE
Register sparkle and impact debris shaders

### DIFF
--- a/nemo-runner/src/lib/game/services/ShaderManager.ts
+++ b/nemo-runner/src/lib/game/services/ShaderManager.ts
@@ -132,6 +132,8 @@ export class ShaderManager {
       const { particleVertexShader } = require('../vfx/shaders/particle.vert');
       const { bubbleFragmentShader } = require('../vfx/shaders/bubble.frag');
       const { dustFragmentShader } = require('../vfx/shaders/dust.frag');
+      const { sparkleFragmentShader } = require('../vfx/shaders/sparkle.frag');
+      const { impactDebrisFragmentShader } = require('../vfx/shaders/impactDebris.frag');
       
       // Register bubble shader immediately
       this.registerShader({
@@ -172,6 +174,44 @@ export class ShaderManager {
         }
       });
       console.log("ShaderManager: Registered dustShader");
+
+      // Register sparkle shader immediately
+      this.registerShader({
+        name: 'sparkleShader',
+        vertexShaderSource: particleVertexShader,
+        fragmentShaderSource: sparkleFragmentShader,
+        defaultUniforms: () => ({
+          uBaseColor: { value: new THREE.Color(0xffffff) },
+          uBaseSize: { value: 0.05 },
+          uPixelRatio: { value: typeof window !== 'undefined' ? window.devicePixelRatio : 1 },
+          uTime: { value: 0.0 },
+        }),
+        materialParameters: {
+          transparent: true,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending,
+        }
+      });
+      console.log("ShaderManager: Registered sparkleShader");
+
+      // Register impact debris shader immediately
+      this.registerShader({
+        name: 'impactDebrisShader',
+        vertexShaderSource: particleVertexShader,
+        fragmentShaderSource: impactDebrisFragmentShader,
+        defaultUniforms: () => ({
+          uBaseColor: { value: new THREE.Color(0xffffff) },
+          uBaseSize: { value: 0.04 },
+          uPixelRatio: { value: typeof window !== 'undefined' ? window.devicePixelRatio : 1 },
+          uTime: { value: 0.0 },
+        }),
+        materialParameters: {
+          transparent: true,
+          depthWrite: false,
+          blending: THREE.NormalBlending,
+        }
+      });
+      console.log("ShaderManager: Registered impactDebrisShader");
       
     } catch (error) {
       console.error("ShaderManager: Error registering particle shaders:", error);

--- a/nemo-runner/src/lib/game/vfx/shaders/impactDebris.frag.ts
+++ b/nemo-runner/src/lib/game/vfx/shaders/impactDebris.frag.ts
@@ -1,0 +1,15 @@
+export const impactDebrisFragmentShader = `
+  varying vec3 vColor;
+  varying float vAlpha;
+
+  uniform vec3 uBaseColor;
+
+  void main() {
+    vec2 uv = gl_PointCoord;
+    float dist = length(uv - vec2(0.5));
+    float mask = 1.0 - smoothstep(0.2, 0.5, dist);
+    if (mask < 0.01) discard;
+    vec3 color = vColor * uBaseColor;
+    gl_FragColor = vec4(color, mask * vAlpha);
+  }
+`;

--- a/nemo-runner/src/lib/game/vfx/shaders/sparkle.frag.ts
+++ b/nemo-runner/src/lib/game/vfx/shaders/sparkle.frag.ts
@@ -1,0 +1,16 @@
+export const sparkleFragmentShader = `
+  varying vec3 vColor;
+  varying float vAlpha;
+
+  uniform vec3 uBaseColor;
+
+  void main() {
+    vec2 uv = gl_PointCoord - vec2(0.5);
+    float dist = length(uv) * 2.0;
+    float spike = max(1.0 - abs(uv.x * 2.0), 1.0 - abs(uv.y * 2.0));
+    float mask = max(1.0 - dist, spike);
+    if (mask < 0.01) discard;
+    vec3 color = vColor * uBaseColor;
+    gl_FragColor = vec4(color, mask * vAlpha);
+  }
+`;


### PR DESCRIPTION
## Summary
- add `sparkleFragmentShader` and `impactDebrisFragmentShader`
- register `sparkleShader` and `impactDebrisShader` in `ShaderManager`

## Testing
- `npx next lint` *(fails: request to https://registry.npmjs.org/next failed, reason: connect EHOSTUNREACH 172.24.0.3:8080)*