### PR TITLE
Fix bubble emitter default

### DIFF
--- a/nemo-runner/src/lib/game/services/VisualEffectsService.ts
+++ b/nemo-runner/src/lib/game/services/VisualEffectsService.ts
@@ -199,7 +199,7 @@ export class VisualEffectsService {
 
   /** Trigger a small bubble trail at the player's position */
   public triggerPlayerTrail(position: THREE.Vector3): void {
-    this.bubbleSystem?.emit(position, 1);
+    this.bubbleSystem?.emit(position);
   }
 
   /** Emit sparkles when a collectible or power-up is picked up */

--- a/nemo-runner/src/lib/game/vfx/particleSystems/BubbleParticleSystem.ts
+++ b/nemo-runner/src/lib/game/vfx/particleSystems/BubbleParticleSystem.ts
@@ -132,16 +132,6 @@ export class BubbleParticleSystem {
     this.updateBufferAttributes(targetIndex, particle);
   }
 
-  /**
-   * Emit a burst of bubbles at the provided origin.
-   * @param origin Position to spawn bubbles around
-   * @param count Number of bubbles to emit
-   */
-  public emit(origin: THREE.Vector3, count: number = 1): void {
-    for (let i = 0; i < count; i++) {
-      this.spawnParticle(origin);
-    }
-  }
 
   private updateBufferAttributes(index: number, particle: BubbleParticle): void {
     this.positions[index * 3] = particle.position.x;
@@ -241,7 +231,10 @@ export class BubbleParticleSystem {
    * @param position The position to emit bubbles from
    * @param count Number of bubbles to emit
    */
-  public emit(position: THREE.Vector3, count: number = 5): void {
+  public emit(
+    position: THREE.Vector3,
+    count: number = configSystem.get('visuals').playerTrailBubbles.burstCount ?? 5
+  ): void {
     for (let i = 0; i < count; i++) {
       this.spawnParticle(position);
     }


### PR DESCRIPTION
## Summary
- remove duplicate emit method
- default BubbleParticleSystem.emit count from config
- simplify VisualEffectsService triggerPlayerTrail call

## Testing
- `npx tsc -p nemo-runner/tsconfig.json --noEmit` *(fails: cannot find type definitions)*
- `npm run lint` *(fails: next not found)*