### PR TITLE
Update bubble trail behavior

### DIFF
--- a/nemo-runner/src/lib/game/managers/PlayerController.ts
+++ b/nemo-runner/src/lib/game/managers/PlayerController.ts
@@ -261,7 +261,11 @@ export class PlayerController {
       this.trailTimer += deltaTime;
       if (this.trailTimer >= interval) {
         this.trailTimer = 0;
-        vfxService.triggerPlayerTrail(this.mesh.position.clone());
+        const trailPosition = this.mesh.position
+          .clone()
+          .add(new THREE.Vector3(0, 0.2, -0.3));
+        const playerVelocity = new THREE.Vector3(0, 0, -this.currentForwardSpeed);
+        vfxService.triggerPlayerTrail(trailPosition, playerVelocity);
       }
     }
 

--- a/nemo-runner/src/lib/game/services/VisualEffectsService.ts
+++ b/nemo-runner/src/lib/game/services/VisualEffectsService.ts
@@ -198,8 +198,8 @@ export class VisualEffectsService {
   }
 
   /** Trigger a small bubble trail at the player's position */
-  public triggerPlayerTrail(position: THREE.Vector3): void {
-    this.bubbleSystem?.emit(position, 1);
+  public triggerPlayerTrail(position: THREE.Vector3, velocity?: THREE.Vector3): void {
+    this.bubbleSystem?.emit(position, 1, velocity);
   }
 
   /** Emit sparkles when a collectible or power-up is picked up */
@@ -277,7 +277,7 @@ export class VisualEffectsService {
 
     // Update Particle Systems
     if (config.enableParticles) {
-      this.bubbleSystem?.update(deltaTime, playerPosition);
+      this.bubbleSystem?.update(deltaTime);
       this.dustSystem?.update(deltaTime, playerPosition);
       this.collectiblePickupSystem?.update(deltaTime);
       this.obstacleImpactSystem?.update(deltaTime);

--- a/nemo-runner/src/lib/game/vfx/particleSystems/BubbleParticleSystem.ts
+++ b/nemo-runner/src/lib/game/vfx/particleSystems/BubbleParticleSystem.ts
@@ -90,7 +90,7 @@ export class BubbleParticleSystem {
     this.scene.add(this.points);
   }
 
-  private spawnParticle(origin: THREE.Vector3): void {
+  private spawnParticle(origin: THREE.Vector3, playerVelocity?: THREE.Vector3): void {
     // Find a "dead" particle (or overwrite oldest)
     let targetIndex = this.particles.findIndex(p => p.lifetime <= 0);
     if (targetIndex === -1 && this.particles.length < this.poolSize) {
@@ -107,17 +107,25 @@ export class BubbleParticleSystem {
     const config = configSystem.get('visuals');
     const bubbleConfig = config.playerTrailBubbles;
     const lifetime = THREE.MathUtils.randFloat(bubbleConfig.lifetimeMin, bubbleConfig.lifetimeMax);
+    const upwardSpeed = THREE.MathUtils.randFloat(
+      bubbleConfig.speedMin,
+      bubbleConfig.speedMax
+    );
+    const inheritedZ = playerVelocity ? playerVelocity.z * 0.25 : 0;
+
     const particle: BubbleParticle = {
-      position: origin.clone().add(new THREE.Vector3(
-        THREE.MathUtils.randFloatSpread(0.1), // Slight horizontal spread at spawn
-        0,
-        THREE.MathUtils.randFloatSpread(0.1)
-      )),
-      // Velocity: upward with slight horizontal drift/wobble
+      position: origin.clone().add(
+        new THREE.Vector3(
+          THREE.MathUtils.randFloatSpread(0.1),
+          0,
+          THREE.MathUtils.randFloatSpread(0.1)
+        )
+      ),
+      // Start with slight inherited backward velocity then rise upward
       velocity: new THREE.Vector3(
         THREE.MathUtils.randFloatSpread(0.05),
-        THREE.MathUtils.randFloat(bubbleConfig.speedMin, bubbleConfig.speedMax),
-        THREE.MathUtils.randFloatSpread(0.05)
+        upwardSpeed,
+        inheritedZ + THREE.MathUtils.randFloatSpread(0.05)
       ),
       lifetime: lifetime,
       maxLifetime: lifetime,
@@ -132,16 +140,6 @@ export class BubbleParticleSystem {
     this.updateBufferAttributes(targetIndex, particle);
   }
 
-  /**
-   * Emit a burst of bubbles at the provided origin.
-   * @param origin Position to spawn bubbles around
-   * @param count Number of bubbles to emit
-   */
-  public emit(origin: THREE.Vector3, count: number = 1): void {
-    for (let i = 0; i < count; i++) {
-      this.spawnParticle(origin);
-    }
-  }
 
   private updateBufferAttributes(index: number, particle: BubbleParticle): void {
     this.positions[index * 3] = particle.position.x;
@@ -155,7 +153,7 @@ export class BubbleParticleSystem {
     this.rotations[index] = particle.rotation;
   }
 
-  public update(deltaTime: number, playerPosition?: THREE.Vector3): void {
+  public update(deltaTime: number): void {
     const config = configSystem.get('visuals');
     const bubbleConfig = config.playerTrailBubbles;
     if (!config.enableParticles || !bubbleConfig.enabled) {
@@ -205,17 +203,6 @@ export class BubbleParticleSystem {
       this.updateBufferAttributes(i, p);
     }
 
-    // Spawn new particles periodically based on player position
-    if (playerPosition && bubbleConfig.emissionRate) {
-      const emissionChance = bubbleConfig.emissionRate * deltaTime / 60; // Convert rate to chance per frame
-      if (Math.random() < emissionChance) {
-        const spawnX = playerPosition.x + THREE.MathUtils.randFloatSpread(config.bubbleSpawnAreaX);
-        // Approximate seafloor height (would be better to query from environment manager)
-        const seafloorY = -1.0; 
-        const spawnPos = new THREE.Vector3(spawnX, seafloorY - config.bubbleSpawnDepth, playerPosition.z);
-        this.spawnParticle(spawnPos);
-      }
-    }
 
     // Mark geometry attributes for GPU update
     this.geometry.attributes.position.needsUpdate = true;
@@ -241,9 +228,9 @@ export class BubbleParticleSystem {
    * @param position The position to emit bubbles from
    * @param count Number of bubbles to emit
    */
-  public emit(position: THREE.Vector3, count: number = 5): void {
+  public emit(position: THREE.Vector3, count: number = 5, playerVelocity?: THREE.Vector3): void {
     for (let i = 0; i < count; i++) {
-      this.spawnParticle(position);
+      this.spawnParticle(position, playerVelocity);
     }
   }
 


### PR DESCRIPTION
## Summary
- refine player bubble trail position and velocity calculations
- pass player velocity into visual effects system
- disable automatic bubble spawning on seafloor
- tune bubble spawn particle motion

## Testing
- `npm run lint` *(fails: `next` not found)*