### PR TITLE
Enhance particle triggers with type data

### DIFF
--- a/nemo-runner/src/lib/game/managers/CollectibleManager.ts
+++ b/nemo-runner/src/lib/game/managers/CollectibleManager.ts
@@ -477,7 +477,7 @@ export class CollectibleManager {
     findAndDeactivate(this.coinData, this.coinInstances, 'coin');
 
     if (worldPos && hitType && this.vfxService) {
-      this.vfxService.triggerCollectiblePickup(worldPos);
+      this.vfxService.triggerCollectiblePickup(worldPos, hitType);
     }
 
     return scoreValue;

--- a/nemo-runner/src/lib/game/managers/ObstacleManager.ts
+++ b/nemo-runner/src/lib/game/managers/ObstacleManager.ts
@@ -921,7 +921,17 @@ export class ObstacleManager {
       hitObstacle.mesh.visible = false;
 
       if (this.vfxService) {
-        this.vfxService.triggerObstacleImpact(hitObstacle.mesh.position.clone());
+        const normal = this.playerController
+          ? hitObstacle.mesh.position
+              .clone()
+              .sub(this.playerController.mesh.position)
+              .normalize()
+          : undefined;
+        this.vfxService.triggerObstacleImpact(
+          hitObstacle.mesh.position.clone(),
+          normal,
+          hitObstacle.type
+        );
       }
 
       // Remove from activeObstacles array

--- a/nemo-runner/src/lib/game/managers/PowerUpManager.ts
+++ b/nemo-runner/src/lib/game/managers/PowerUpManager.ts
@@ -255,7 +255,10 @@ export class PowerUpManager {
     this.returnPowerUpToPool(collectedAsset);
 
     if (this.vfxService) {
-      this.vfxService.triggerCollectiblePickup(collectedAsset.getMesh().position.clone());
+      this.vfxService.triggerCollectiblePickup(
+        collectedAsset.getMesh().position.clone(),
+        type
+      );
     }
 
     // Remove any existing effect of the same type to reset duration

--- a/nemo-runner/src/lib/game/services/VisualEffectsService.ts
+++ b/nemo-runner/src/lib/game/services/VisualEffectsService.ts
@@ -203,13 +203,40 @@ export class VisualEffectsService {
   }
 
   /** Emit sparkles when a collectible or power-up is picked up */
-  public triggerCollectiblePickup(position: THREE.Vector3): void {
-    this.collectiblePickupSystem?.emit(position, 10);
+  public triggerCollectiblePickup(
+    position: THREE.Vector3,
+    type: 'bubble' | 'coin' | 'shield' | 'magnet' | 'doublescore' = 'bubble'
+  ): void {
+    if (!configSystem.get('visuals').enableParticles) return;
+    const colors: Record<string, THREE.Color> = {
+      bubble: new THREE.Color(0xb0e0e6),
+      coin: new THREE.Color(0xffd700),
+      shield: new THREE.Color(0x00aaff),
+      magnet: new THREE.Color(0xff0066),
+      doublescore: new THREE.Color(0xffd700)
+    };
+    const color = colors[type] || new THREE.Color(0xffffff);
+    this.collectiblePickupSystem?.emit(position, color, 10);
   }
 
   /** Emit debris when the player hits an obstacle */
-  public triggerObstacleImpact(position: THREE.Vector3): void {
-    this.obstacleImpactSystem?.emit(position, 15);
+  public triggerObstacleImpact(
+    position: THREE.Vector3,
+    normal?: THREE.Vector3,
+    obstacleType?: string
+  ): void {
+    if (!configSystem.get('visuals').enableParticles) return;
+    const colors: Record<string, THREE.Color> = {
+      clam: new THREE.Color(0xffaa88),
+      pufferfish: new THREE.Color(0xffdd55),
+      jellyfish: new THREE.Color(0xaa88ff),
+      shark: new THREE.Color(0x999999),
+      seaTurtle: new THREE.Color(0x00ffaa),
+      kelpWall: new THREE.Color(0x66aa44),
+      schoolOfFish: new THREE.Color(0xaaaaff)
+    };
+    const color = obstacleType ? colors[obstacleType] || new THREE.Color(0xffffff) : new THREE.Color(0xffffff);
+    this.obstacleImpactSystem?.emit(position, normal, color);
   }
 
   /** Trigger a special effect when shield absorbs a hit */
@@ -229,7 +256,7 @@ export class VisualEffectsService {
       doublescore: new THREE.Color(0xffd700)
     };
     const color = colors[type] || new THREE.Color(0xffffff);
-    this.collectiblePickupSystem?.emit(position, type as any, color);
+    this.collectiblePickupSystem?.emit(position, color, 10);
   }
 
   /**

--- a/nemo-runner/src/lib/game/vfx/particleSystems/CollectiblePickupParticleSystem.ts
+++ b/nemo-runner/src/lib/game/vfx/particleSystems/CollectiblePickupParticleSystem.ts
@@ -33,8 +33,11 @@ export class CollectiblePickupParticleSystem {
     }
   }
 
-  public emit(origin: THREE.Vector3, count: number = 10): void {
+  public emit(origin: THREE.Vector3, color?: THREE.Color, count: number = 10): void {
     if (!this.points || !this.positions) return;
+    if (color && this.material instanceof THREE.PointsMaterial) {
+      (this.material as THREE.PointsMaterial).color.copy(color);
+    }
     for (let c = 0; c < count; c++) {
       const index = c % this.poolSize;
       this.particles[index].copy(origin);

--- a/nemo-runner/src/lib/game/vfx/particleSystems/ObstacleImpactParticleSystem.ts
+++ b/nemo-runner/src/lib/game/vfx/particleSystems/ObstacleImpactParticleSystem.ts
@@ -31,8 +31,16 @@ export class ObstacleImpactParticleSystem {
     }
   }
 
-  public emit(origin: THREE.Vector3, count: number = 15): void {
+  public emit(
+    origin: THREE.Vector3,
+    normal?: THREE.Vector3,
+    color?: THREE.Color,
+    count: number = 15
+  ): void {
     if (!this.positions || !this.points) return;
+    if (color && this.material instanceof THREE.PointsMaterial) {
+      (this.material as THREE.PointsMaterial).color.copy(color);
+    }
     for (let c = 0; c < count; c++) {
       const index = c % this.poolSize;
       this.positions[index*3] = origin.x;


### PR DESCRIPTION
## Summary
- allow CollectiblePickupParticleSystem and ObstacleImpactParticleSystem to use colors
- forward collectible/obstacle type info via VisualEffectsService
- update managers to pass new parameters
- propagate player position to BubbleParticleSystem update

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next')*