### PR TITLE
Add reset methods for particle systems

### DIFF
--- a/nemo-runner/src/lib/game/services/VisualEffectsService.ts
+++ b/nemo-runner/src/lib/game/services/VisualEffectsService.ts
@@ -367,6 +367,8 @@ export class VisualEffectsService {
       if (this.dustSystem && !this.dustSystem.points.visible) {
         this.dustSystem.points.visible = true;
       }
+      this.bubbleSystem?.reset();
+      this.dustSystem?.reset();
       this.collectiblePickupSystem?.reset();
       this.obstacleImpactSystem?.reset();
     }

--- a/nemo-runner/src/lib/game/vfx/particleSystems/BubbleParticleSystem.ts
+++ b/nemo-runner/src/lib/game/vfx/particleSystems/BubbleParticleSystem.ts
@@ -245,6 +245,26 @@ export class BubbleParticleSystem {
     }
   }
 
+  public reset(): void {
+    this.particles = [];
+    for (let i = 0; i < this.poolSize; i++) {
+      this.positions[i * 3] = 0;
+      this.positions[i * 3 + 1] = -9999;
+      this.positions[i * 3 + 2] = 0;
+      this.scales[i] = 0;
+      this.alphas[i] = 0;
+      this.colors[i * 3] = 1;
+      this.colors[i * 3 + 1] = 1;
+      this.colors[i * 3 + 2] = 1;
+      this.rotations[i] = 0;
+    }
+    this.geometry.attributes.position.needsUpdate = true;
+    this.geometry.attributes.aScale.needsUpdate = true;
+    this.geometry.attributes.aAlpha.needsUpdate = true;
+    this.geometry.attributes.aColor.needsUpdate = true;
+    this.geometry.attributes.aRotation.needsUpdate = true;
+  }
+
   public dispose(): void {
     this.scene.remove(this.points);
     this.geometry.dispose();

--- a/nemo-runner/src/lib/game/vfx/particleSystems/DustParticleSystem.ts
+++ b/nemo-runner/src/lib/game/vfx/particleSystems/DustParticleSystem.ts
@@ -178,6 +178,41 @@ export class DustParticleSystem {
     }
   }
 
+  public reset(): void {
+    for (let i = 0; i < this.poolSize; i++) {
+      const pos = randomPointInSphere(this.spawnRadius).add(this.centerPosition);
+      this.positions[i * 3] = pos.x;
+      this.positions[i * 3 + 1] = pos.y;
+      this.positions[i * 3 + 2] = pos.z;
+
+      const scale = THREE.MathUtils.randFloat(0.5, 1.5);
+      this.scales[i] = scale;
+      const alpha = THREE.MathUtils.randFloat(0.1, 0.5);
+      this.alphas[i] = alpha;
+
+      const greyValue = THREE.MathUtils.randFloat(0.6, 0.9);
+      this.colors[i * 3] = greyValue;
+      this.colors[i * 3 + 1] = greyValue;
+      this.colors[i * 3 + 2] = greyValue;
+
+      this.particles[i] = {
+        position: pos.clone(),
+        velocity: new THREE.Vector3(),
+        lifetime: Infinity,
+        maxLifetime: Infinity,
+        scale,
+        alpha,
+        color: new THREE.Color(greyValue, greyValue, greyValue),
+        wanderTarget: new THREE.Vector3(),
+        wanderTheta: Math.random() * Math.PI * 2,
+      };
+    }
+    this.geometry.attributes.position.needsUpdate = true;
+    this.geometry.attributes.aScale.needsUpdate = true;
+    this.geometry.attributes.aAlpha.needsUpdate = true;
+    this.geometry.attributes.aColor.needsUpdate = true;
+  }
+
   public dispose(): void {
     this.scene.remove(this.points);
     this.geometry.dispose();


### PR DESCRIPTION
## Summary
- add `reset` implementation to `BubbleParticleSystem`
- add `reset` implementation to `DustParticleSystem`
- invoke these resets from `VisualEffectsService.reset`

## Testing
- `npm run lint` *(fails: `next` not found)*