### PR TITLE
Fix initial flash with fog color

### DIFF
--- a/nemo-runner/src/app/layout.tsx
+++ b/nemo-runner/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { configSystem } from "@/lib/game/core/ConfigurationSystem";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -14,9 +15,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const fogColor = configSystem.getLightingConfig().fogColor;
+  const fogHex = `#${fogColor.toString(16).padStart(6, '0')}`;
   return (
     <html lang="en">
-      <body className={inter.className} style={{ margin: 0, padding: 0 }}>
+      <body
+        className={inter.className}
+        style={{ margin: 0, padding: 0, backgroundColor: fogHex }}
+      >
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- use lighting config fog color when rendering the initial `<body>`

## Testing
- `npm run lint` *(fails: `next` not found)*