### PR TITLE
Pass renderer canvas to InputHandler

### DIFF
--- a/nemo-runner/src/lib/game/GameEngine.ts
+++ b/nemo-runner/src/lib/game/GameEngine.ts
@@ -171,6 +171,7 @@ export class GameEngine {
 
       // Input Handler
       this.inputHandler = new InputHandler(this.playerController);
+      this.inputHandler.setGameCanvasElement(this.renderer.domElement as HTMLElement);
       this.inputHandler.initialize();
 
       // ObstacleManager

--- a/nemo-runner/src/lib/game/core/InputHandler.ts
+++ b/nemo-runner/src/lib/game/core/InputHandler.ts
@@ -3,6 +3,7 @@ import { PlayerController } from '../managers/PlayerController';
 export class InputHandler {
   private playerController: PlayerController;
   private keysPressed: { [key: string]: boolean } = {};
+  private gameCanvasElement: HTMLElement | null = null;
   private boundHandleKeyDown: (event: KeyboardEvent) => void;
   private boundHandleKeyUp: (event: KeyboardEvent) => void;
 
@@ -11,6 +12,10 @@ export class InputHandler {
     // Bind methods to ensure 'this' context is correct in event handlers
     this.boundHandleKeyDown = this.handleKeyDown.bind(this);
     this.boundHandleKeyUp = this.handleKeyUp.bind(this);
+  }
+
+  public setGameCanvasElement(element: HTMLElement): void {
+    this.gameCanvasElement = element;
   }
 
   public initialize(): void {


### PR DESCRIPTION
## Summary
- attach WebGL canvas to InputHandler in GameEngine
- store game canvas element in InputHandler

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*