### PR TITLE
Add Jest tests for InputHandler swipe detection

### DIFF
--- a/nemo-runner/jest.config.js
+++ b/nemo-runner/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  testMatch: ['**/*.test.ts']
+};

--- a/nemo-runner/package.json
+++ b/nemo-runner/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@types/three": "^0.176.0",
@@ -24,6 +25,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.11"
   }
 }

--- a/nemo-runner/src/lib/game/core/InputHandler.test.ts
+++ b/nemo-runner/src/lib/game/core/InputHandler.test.ts
@@ -1,0 +1,119 @@
+import { InputHandler } from './InputHandler';
+import { PlayerController } from '../managers/PlayerController';
+import { configSystem } from './ConfigurationSystem';
+
+describe('InputHandler - processSwipe', () => {
+  let inputHandler: InputHandler;
+  let mockPlayerController: jest.Mocked<PlayerController>;
+  let mockCanvas: HTMLElement;
+
+  const mockTouchConfig = {
+    swipeMinDistance: 40,
+    swipeMaxDuration: 500,
+    swipeAngleThreshold: Math.PI / 5,
+  };
+
+  beforeEach(() => {
+    jest.spyOn(configSystem, 'get').mockImplementation((key: any) => {
+      if (key === 'touchControls') {
+        return mockTouchConfig as any;
+      }
+      return {} as any;
+    });
+
+    mockPlayerController = {
+      moveLeft: jest.fn(),
+      moveRight: jest.fn(),
+      jump: jest.fn(),
+      dive: jest.fn(),
+    } as any;
+
+    mockCanvas = document.createElement('div');
+    inputHandler = new InputHandler(mockPlayerController);
+    (inputHandler as any).touchConfig = mockTouchConfig;
+  });
+
+  const testSwipe = (
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    duration: number
+  ) => {
+    (inputHandler as any).processSwipe(startX, startY, endX, endY, duration);
+  };
+
+  it('detects upward swipe', () => {
+    testSwipe(100, 200, 105, 100, 100);
+    expect(mockPlayerController.jump).toHaveBeenCalled();
+  });
+
+  it('detects downward swipe', () => {
+    testSwipe(100, 100, 95, 200, 100);
+    expect(mockPlayerController.dive).toHaveBeenCalled();
+  });
+
+  it('detects left swipe', () => {
+    testSwipe(200, 100, 100, 105, 100);
+    expect(mockPlayerController.moveLeft).toHaveBeenCalled();
+  });
+
+  it('detects right swipe', () => {
+    testSwipe(100, 100, 200, 95, 100);
+    expect(mockPlayerController.moveRight).toHaveBeenCalled();
+  });
+
+  it('ignores short swipes', () => {
+    testSwipe(100, 100, 100, 100 + mockTouchConfig.swipeMinDistance - 1, 100);
+    expect(mockPlayerController.dive).not.toHaveBeenCalled();
+  });
+
+  it('ignores long-duration swipes', () => {
+    testSwipe(
+      100,
+      100,
+      100,
+      100 + mockTouchConfig.swipeMinDistance + 10,
+      mockTouchConfig.swipeMaxDuration + 1
+    );
+    expect(mockPlayerController.dive).not.toHaveBeenCalled();
+  });
+
+  it('interprets slight diagonal up as jump', () => {
+    testSwipe(
+      100,
+      200,
+      100 + mockTouchConfig.swipeMinDistance * 0.3,
+      100,
+      100
+    );
+    expect(mockPlayerController.jump).toHaveBeenCalled();
+    expect(mockPlayerController.moveRight).not.toHaveBeenCalled();
+  });
+
+  it('interprets slight diagonal right as right', () => {
+    testSwipe(
+      100,
+      100,
+      200,
+      100 - mockTouchConfig.swipeMinDistance * 0.3,
+      100
+    );
+    expect(mockPlayerController.moveRight).toHaveBeenCalled();
+    expect(mockPlayerController.jump).not.toHaveBeenCalled();
+  });
+
+  it('ignores ambiguous diagonal', () => {
+    testSwipe(
+      100,
+      100,
+      100 + mockTouchConfig.swipeMinDistance,
+      100 + mockTouchConfig.swipeMinDistance,
+      100
+    );
+    expect(mockPlayerController.jump).not.toHaveBeenCalled();
+    expect(mockPlayerController.dive).not.toHaveBeenCalled();
+    expect(mockPlayerController.moveLeft).not.toHaveBeenCalled();
+    expect(mockPlayerController.moveRight).not.toHaveBeenCalled();
+  });
+});

--- a/nemo-runner/src/lib/game/core/InputHandler.ts
+++ b/nemo-runner/src/lib/game/core/InputHandler.ts
@@ -1,16 +1,35 @@
 import { PlayerController } from '../managers/PlayerController';
+import { configSystem } from './ConfigurationSystem';
 
 export class InputHandler {
   private playerController: PlayerController;
   private keysPressed: { [key: string]: boolean } = {};
   private boundHandleKeyDown: (event: KeyboardEvent) => void;
   private boundHandleKeyUp: (event: KeyboardEvent) => void;
+  private touchConfig: {
+    swipeMinDistance: number;
+    swipeMaxDuration: number;
+    swipeAngleThreshold: number;
+  };
 
   constructor(playerController: PlayerController) {
     this.playerController = playerController;
     // Bind methods to ensure 'this' context is correct in event handlers
     this.boundHandleKeyDown = this.handleKeyDown.bind(this);
     this.boundHandleKeyUp = this.handleKeyUp.bind(this);
+
+    const tc = (configSystem.get as any)(
+      'touchControls' as any
+    ) as Partial<{
+      swipeMinDistance: number;
+      swipeMaxDuration: number;
+      swipeAngleThreshold: number;
+    }>;
+    this.touchConfig = {
+      swipeMinDistance: tc?.swipeMinDistance ?? 40,
+      swipeMaxDuration: tc?.swipeMaxDuration ?? 500,
+      swipeAngleThreshold: tc?.swipeAngleThreshold ?? Math.PI / 5
+    };
   }
 
   public initialize(): void {
@@ -52,6 +71,60 @@ export class InputHandler {
 
   public update(deltaTime: number): void {
     // No continuous movement for lane system; handled on keydown only
+  }
+
+  // Process a swipe gesture. Exposed for testing but used internally by touch handlers.
+  private processSwipe(
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    deltaTime: number
+  ): void {
+    if (deltaTime > this.touchConfig.swipeMaxDuration) {
+      return;
+    }
+
+    const deltaX = endX - startX;
+    const deltaY = endY - startY;
+    const absDeltaX = Math.abs(deltaX);
+    const absDeltaY = Math.abs(deltaY);
+
+    if (Math.max(absDeltaX, absDeltaY) < this.touchConfig.swipeMinDistance) {
+      return;
+    }
+
+    const angle = Math.atan2(deltaY, deltaX);
+
+    if (absDeltaX > absDeltaY) {
+      if (absDeltaX >= this.touchConfig.swipeMinDistance) {
+        if (
+          Math.abs(angle) < this.touchConfig.swipeAngleThreshold ||
+          Math.abs(angle) > Math.PI - this.touchConfig.swipeAngleThreshold
+        ) {
+          if (deltaX > 0) {
+            this.playerController.moveRight();
+          } else {
+            this.playerController.moveLeft();
+          }
+          return;
+        }
+      }
+    } else {
+      if (absDeltaY >= this.touchConfig.swipeMinDistance) {
+        if (
+          Math.abs(angle - Math.PI / 2) < this.touchConfig.swipeAngleThreshold ||
+          Math.abs(angle + Math.PI / 2) < this.touchConfig.swipeAngleThreshold
+        ) {
+          if (deltaY > 0) {
+            this.playerController.dive();
+          } else {
+            this.playerController.jump();
+          }
+          return;
+        }
+      }
+    }
   }
 
   public dispose(): void {


### PR DESCRIPTION
## Summary
- set up Jest with ts-jest
- implement swipe detection helper in `InputHandler`
- add unit tests for swipe detection behavior

## Testing
- `npm test` *(fails: jest not found)*